### PR TITLE
Remove decorator return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Root package Typescript dependency changed to `^5.4.2`.
 * `@typescript-eslint/eslint-plugin` upgraded to `^7.1.1`, in root package.
+* Decorator return types for `meta()`, `targetMeta()`, and `inheritTargetMeta()` (_continued to cause TS1270 and TS1238 errors_). [#8](https://github.com/aedart/ion/pull/8).
 
 ### Fixed
 

--- a/packages/support/src/meta/meta.ts
+++ b/packages/support/src/meta/meta.ts
@@ -1,4 +1,3 @@
-import type { Decorator } from "@aedart/contracts";
 import type { Key } from "@aedart/contracts/support";
 import type {
     Context,
@@ -32,8 +31,7 @@ import { getMetaRepository } from "./getMetaRepository";
 export function meta(
     key: Key | MetaCallback,
     value?: unknown
-): Decorator
-{
+) {
     return (target: object, context: Context) => {
         return getMetaRepository({}).set(target, context, key, value);
     }

--- a/packages/support/src/meta/target/inheritTargetMeta.ts
+++ b/packages/support/src/meta/target/inheritTargetMeta.ts
@@ -1,4 +1,3 @@
-import type { ClassMethodDecorator } from "@aedart/contracts";
 import type { Context } from "@aedart/contracts/support/meta";
 import { getTargetMetaRepository } from "./getTargetMetaRepository";
 
@@ -35,7 +34,7 @@ import { getTargetMetaRepository } from "./getTargetMetaRepository";
  * @throws {MetaError} When decorated element's owner class has no parent, or when no "target" metadata available
  *                     on parent element.
  */
-export function inheritTargetMeta(): ClassMethodDecorator
+export function inheritTargetMeta()
 {
     return (target: object, context: Context) => {
         return getTargetMetaRepository().inherit(target, context);

--- a/packages/support/src/meta/target/targetMeta.ts
+++ b/packages/support/src/meta/target/targetMeta.ts
@@ -1,7 +1,3 @@
-import type {
-    ClassDecorator,
-    ClassMethodDecorator
-} from "@aedart/contracts";
 import type { Key } from "@aedart/contracts/support";
 import type {
     Context,
@@ -39,8 +35,7 @@ import { getTargetMetaRepository } from "./getTargetMetaRepository";
 export function targetMeta(
     key: Key | MetaCallback,
     value?: unknown
-): ClassDecorator | ClassMethodDecorator 
-{
+) {
     return (target: object, context: Context) => {
         return getTargetMetaRepository().set(target, context, key, value);
     }


### PR DESCRIPTION
Returns types for `meta()`, `targetMeta()`, and `inheritTargetMeta()` have now been removed. They continued to cause TS1270 and TS1238 errors.
Each of these decorators now have implicit any return type and should therefore not cause more issues (_hopefully_)!

## References

* #8 
